### PR TITLE
fix(image): fix new line addition above image issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "draft-js": "^0.11.7",
-    "draftjs-to-html": "^0.9.1",
+    "draftjs-to-html": "^0.9.0",
     "draftjs-utils": "^0.10.2",
     "html-to-draftjs": "^1.5.0",
     "immutable": "^4.0.0-rc.12",

--- a/src/Preview/index.js
+++ b/src/Preview/index.js
@@ -92,7 +92,7 @@ const defaultEntities = {
     const imageAlign = alignment ? alignment : 'left';
 
     return (
-      <p style={{ justifyContent: imageAlign, display: 'flex' }}>
+      <p id='RichTextEditor-Image' style={{ justifyContent: imageAlign, display: 'flex' }}>
         <img src={src} alt={alt} height={height} width={width} />
       </p>
     );

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -4,7 +4,8 @@ import { ContentState, EditorState, convertToRaw } from 'draft-js';
 
 export const htmlToState = (html) => {
   // Remove extra newline in html generated from Preview component
-  const htmlContent = html.replaceAll('<br/>', '');
+  const imgContent = html.replaceAll('<p><br/></p><p id="RichTextEditor-Image"','<p id="RichTextEditor-Image"');
+  const htmlContent = imgContent.replaceAll('<br/>', '');
   const contentBlock = htmlToDraft(htmlContent);
   if (contentBlock) {
     const contentState = ContentState.createFromBlockArray(contentBlock.contentBlocks);


### PR DESCRIPTION
**Issue:**

1. Enter an Image inside the editor
2. Generate Html for content
3. Again Pass this Html to the editor
4. Editor will add unnecessarily newline above the image 
