### PR TITLE
fix(mention): hide find suggestion text

### DIFF
--- a/src/decorators/Mention/Suggestion/index.js
+++ b/src/decorators/Mention/Suggestion/index.js
@@ -223,8 +223,9 @@ function getSuggestionComponent() {
       const editorState = config.getEditorState();
       const { onChange, separator, trigger } = config;
       const selectedMention = this.filteredSuggestions[activeOption];
+      const mentionText = this.props.children[0].props.text.substr(1);
       if (selectedMention) {
-        addMention(editorState, onChange, separator, trigger, selectedMention, eventName);
+        addMention(editorState, onChange, separator, trigger, selectedMention, eventName, mentionText);
       }
     };
 

--- a/src/decorators/Mention/addMention.js
+++ b/src/decorators/Mention/addMention.js
@@ -7,7 +7,8 @@ export default function addMention(
   separator: string,
   trigger: string,
   suggestion: Object,
-  mouseSelect: string
+  mouseSelect: string,
+  mentionText: string
 ): void {
   const { label, value, url } = suggestion;
 
@@ -27,7 +28,7 @@ export default function addMention(
     spaceAlreadyPresent = true;
   }
   if (mouseSelect) {
-    focusOffset = mentionIndex + 1;
+    focusOffset = mentionIndex + mentionText.length + 1;
   }
   let updatedSelection = editorState.getSelection().merge({
     anchorOffset: mentionIndex,


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

While using the Mention component, if the user inserts any text after @  then it does not automatically hide after the mention option selection.

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
