### PR TITLE
fix(list): fix unordered list padding issue in preview component

### DIFF
--- a/src/Preview/index.js
+++ b/src/Preview/index.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import redraft, { createStylesRenderer } from 'redraft';
-import { Heading, Text, Link, Chip, Paragraph } from '@innovaccer/design-system';
+import { Heading, Link, Paragraph } from '@innovaccer/design-system';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { defaultColors } from '../config/defaultToolbar';
 
 const listStyle = {
-  padding: '0px',
+  paddingLeft: '1.5em',
   margin: '0px',
 };
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
This PR resolves the following issues

- Bullet points → Adding bullet or number indexing is not showing any margin/padding in generated HTML. The same happens for nested bullet points.

- The nested List (Bullet points) does not appear correctly in Preview Component.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
