### PR TITLE
fix(editor): add delete key handler

### DIFF
--- a/src/Editor/index.js
+++ b/src/Editor/index.js
@@ -169,6 +169,13 @@ class Editor extends Component {
         }
       }
     }
+    if (event.key === 'Delete') {
+      const newState = RichUtils.onDelete(this.state.editorState);
+      if (newState) {
+        this.onChange(newState);
+        return true;
+      }
+    }
     return getDefaultKeyBinding(event);
   };
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Issue: Delete key deletes image block but entity persists in editor which appears in preview and html
Fixed: Delete key deletes image entity from editor
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
