### PR TITLE
fix(image): left & right floating images

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -14,10 +14,11 @@ export const htmlToState = (html) => {
   }
 };
 
-export const stateToHTML = (editorState) => {
+export const stateToHTML = (editorState, nonFloatingImages = false) => {
   const json = convertToRaw(editorState.getCurrentContent());
 
   return draftToHtml(json, {}, false, ({ type, data }) => {
+
     if (type === 'IMAGE') {
       const alignment = data.alignment ? data.alignment : 'left';
       if(data.alt==="center" || alignment === "center")
@@ -28,10 +29,12 @@ export const stateToHTML = (editorState) => {
         `;
       else
         return `
-          <p>
+          <p style="${nonFloatingImages ? 'display: flow-root;' : ''}">
             <img src="${data.src}" alt="${data.alignment}" style="float:${alignment}; height: ${data.height};width: ${data.width}"/>
           </p>
         `;
     }
+
+    
   });
 };


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
 Added the condition for float left and right image -> display: flow-root based on a flag in the stateToHTML function. So, if we are using the html outside it just leaves the left and right alignment with text alongside which we don't look similar to the editor.
 
 There were two solutions that were discussed out of which we choose this one.