### PR TITLE
fix(image): update image alignment floating based on nonFloatingImage…

### DIFF
--- a/src/Editor/index.js
+++ b/src/Editor/index.js
@@ -51,12 +51,13 @@ class Editor extends Component {
     this.modalHandler = new ModalHandler();
     this.focusHandler = new FocusHandler();
     const showImageResizeOption = props.toolbar && props.toolbar.insert && props.toolbar.insert.image?.resizeEnabled;
-
+    const showNonFloatingImageOption = props.toolbar && props.toolbar.insert && props.toolbar.insert.image?.nonFloatingImage;
     this.blockRendererFn = getBlockRenderFunc(
       {
         isReadOnly: true,
         isImageAlignmentEnabled: this.isImageAlignmentEnabled,
         isImageResizeEnabled: showImageResizeOption,
+        nonFloatingImage: showNonFloatingImageOption,
         getEditorState: this.getEditorState,
         onChange: this.onChange,
       }

--- a/src/renderer/Image/index.js
+++ b/src/renderer/Image/index.js
@@ -138,8 +138,9 @@ const getImageComponent = (config) =>
         this.setEntityAlignmentCenter();
       } else if (nonFloatingImage && alt === 'right' && !alignment) {
         this.setEntityAlignmentRight();
-      } else if (nonFloatingImage && alt === 'left' && !alignment)
+      } else if (nonFloatingImage && alt === 'left' && !alignment) {
         this.setEntityAlignmentLeft();
+      }
 
       const editorRef = document.getElementById('RichTextEditorWrapper');
 

--- a/src/renderer/Image/index.js
+++ b/src/renderer/Image/index.js
@@ -130,13 +130,16 @@ const getImageComponent = (config) =>
     render() {
       const { block, contentState } = this.props;
       const { hovered } = this.state;
-      const { isImageAlignmentEnabled, isImageResizeEnabled } = config;
+      const { isImageAlignmentEnabled, isImageResizeEnabled, nonFloatingImage } = config;
       const entity = contentState.getEntity(block.getEntityAt(0));
       const { src, alignment, height, width, alt } = entity.getData();
 
       if (alt === 'center' && !alignment) {
         this.setEntityAlignmentCenter();
-      }
+      } else if (nonFloatingImage && alt === 'right' && !alignment) {
+        this.setEntityAlignmentRight();
+      } else if (nonFloatingImage && alt === 'left' && !alignment)
+        this.setEntityAlignmentLeft();
 
       const editorRef = document.getElementById('RichTextEditorWrapper');
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -28,7 +28,7 @@ export const stateToHTML = (editorState, nonFloatingImage = false) => {
           <img src="${data.src}" alt="${data.alignment}" style="display:block; margin-right:auto; margin-left:auto; height: ${data.height};width: ${data.width}"/>
         </p>
         `;
-      else if(nonFloatingImage && data.alt === "left" || alignment === "left")
+      else if(nonFloatingImage && (data.alt === "left" || alignment === "left"))
         return `
           <p>
             <img src="${data.src}" alt="${data.alignment}" style="display:block; margin-right:auto; height: ${data.height};width: ${data.width}"/>

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -14,7 +14,7 @@ export const htmlToState = (html) => {
   }
 };
 
-export const stateToHTML = (editorState) => {
+export const stateToHTML = (editorState, notFloatingImage = false) => {
   const json = convertToRaw(editorState.getCurrentContent());
 
   return draftToHtml(json, {}, false, ({ type, data }) => {
@@ -26,12 +26,25 @@ export const stateToHTML = (editorState) => {
           <img src="${data.src}" alt="${data.alignment}" style="display:block; margin-right:auto; margin-left:auto; height: ${data.height};width: ${data.width}"/>
         </p>
         `;
-      else
+      else if(notFloatingImage && data.alt ==="left" || alignment === "left")
         return `
           <p>
-            <img src="${data.src}" alt="${data.alignment}" style="float:${alignment}; height: ${data.height};width: ${data.width}"/>
+            <img src="${data.src}" alt="${data.alignment}" style="display:block; margin-right:auto; height: ${data.height};width: ${data.width}"/>
           </p>
         `;
+      else if(notFloatingImage)
+        return `
+          <p>
+            <img src="${data.src}" alt="${data.alignment}" style="display:block; margin-left:auto; height: ${data.height};width: ${data.width}"/>
+          </p>
+        `;
+      else
+          return `
+            <p>
+              <img src="${data.src}" alt="${data.alignment}" style="float:${alignment}; height: ${data.height};width: ${data.width}"/>
+            </p>
+          `;
     }
+    
   });
 };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -15,7 +15,7 @@ export const htmlToState = (html) => {
 };
 
 
-export const stateToHTML = (editorState, notFloatingImage = false) => {
+export const stateToHTML = (editorState, nonFloatingImage = false) => {
   const json = convertToRaw(editorState.getCurrentContent());
 
   return draftToHtml(json, {}, false, ({ type, data }) => {
@@ -28,13 +28,13 @@ export const stateToHTML = (editorState, notFloatingImage = false) => {
           <img src="${data.src}" alt="${data.alignment}" style="display:block; margin-right:auto; margin-left:auto; height: ${data.height};width: ${data.width}"/>
         </p>
         `;
-      else if(notFloatingImage && data.alt === "left" || alignment === "left")
+      else if(nonFloatingImage && data.alt === "left" || alignment === "left")
         return `
           <p>
             <img src="${data.src}" alt="${data.alignment}" style="display:block; margin-right:auto; height: ${data.height};width: ${data.width}"/>
           </p>
         `;
-      else if(notFloatingImage)
+      else if(nonFloatingImage)
         return `
           <p>
             <img src="${data.src}" alt="${data.alignment}" style="display:block; margin-left:auto; height: ${data.height};width: ${data.width}"/>


### PR DESCRIPTION
… in exported html

### What does this implement/fix? Explain your changes.
Earlier, I added the condition for float left and right image -> display: flow-root based on a flag in the stateToHTML function. So, if we are using the html outside it just leaves the left and right alignment with text alongside which doesn't look similar to the editor. But, html-pdf library does not support that. 

The current Implementation is based on a flag nonFloatingImage which calls setAlignment function according to the alignment left or right otherwise it was working fine.
