### PR TITLE
fix(image): remove image alignment popover from readonly editor

### DIFF
--- a/src/Editor/index.js
+++ b/src/Editor/index.js
@@ -54,7 +54,7 @@ class Editor extends Component {
     const showNonFloatingImageOption = props.toolbar && props.toolbar.insert && props.toolbar.insert.image?.nonFloatingImage;
     this.blockRendererFn = getBlockRenderFunc(
       {
-        isReadOnly: true,
+        isReadOnly: props.readOnly,
         isImageAlignmentEnabled: this.isImageAlignmentEnabled,
         isImageResizeEnabled: showImageResizeOption,
         nonFloatingImage: showNonFloatingImageOption,

--- a/src/renderer/Image/index.js
+++ b/src/renderer/Image/index.js
@@ -130,7 +130,7 @@ const getImageComponent = (config) =>
     render() {
       const { block, contentState } = this.props;
       const { hovered } = this.state;
-      const { isImageAlignmentEnabled, isImageResizeEnabled, nonFloatingImage } = config;
+      const { isImageAlignmentEnabled, isImageResizeEnabled, isReadOnly, nonFloatingImage } = config;
       const entity = contentState.getEntity(block.getEntityAt(0));
       const { src, alignment, height, width, alt } = entity.getData();
 
@@ -173,7 +173,7 @@ const getImageComponent = (config) =>
               }}
               ref={this.imageRef}
             />
-            {hovered && (
+            {!isReadOnly && hovered && (
               <>
                 {isImageAlignmentEnabled() && this.renderAlignmentOptions(isImageResizeEnabled)}
                 {isImageResizeEnabled && (


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Removed image toolbar appear in read only access mode of Rich text Editor
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
